### PR TITLE
Fix builder, update package names

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -70,4 +70,5 @@ linux:
     icon: build/icons
     category: Utility
     desktop:
-        StartupWMClass: fluent-reader
+        entry:
+            StartupWMClass: fluent-flame-reader

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -1,6 +1,6 @@
-appId: me.hyliu.fluentreader
-productName: Fluent Reader
-copyright: Copyright © 2020 Haoyuan Liu
+appId: org.fluentflame.fluentflamereader
+productName: Fluent Flame Reader
+copyright: Fluent Flame Copyright © 2025 Nube & Individual Collaborators. Original copyright © 2020 Haoyuan Liu
 files:
     - "./dist/**/*"
     - "!./dist/fontlist"
@@ -35,9 +35,9 @@ win:
         - nsis
         - zip
 appx:
-    applicationId: FluentReader
-    identityName: 25286HaoyuanLiu.FluentReader
-    publisher: CN=FD70E7FA-E5AC-41C4-B9C4-6E8708A6616A
+    applicationId: FluentFlameReader
+    identityName: TODO.FluentFlameReader
+    publisher: TODO
     backgroundColor: transparent
     languages:
         - zh-CN

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "fluent-reader",
+  "name": "fluent-flame-reader",
   "version": "1.1.4",
   "description": "Modern desktop RSS reader",
   "main": "./dist/electron.js",
@@ -17,7 +17,7 @@
   "keywords": [],
   "author": "Haoyuan Liu",
   "license": "BSD-3-Clause",
-  "repository": "github:yang991178/fluent-reader",
+  "repository": "github:FluentFlame/fluent-flame-reader",
   "devDependencies": {
     "@fluentui/react": "^7.126.2",
     "@types/lovefield": "^2.1.3",


### PR DESCRIPTION
This fixes a bug where the electron-builder.yml has an incorrect `.desktop` entry setting, as it's incorrectly nested.
See upstream electron-builder specification here: https://www.electron.build/app-builder-lib.interface.linuxdesktopfile#entry