### PR TITLE
Unify naming scheme, fix nix desktop item

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center">
   <img width="120" height="120" src="https://github.com/yang991178/fluent-reader/raw/master/build/icon.png">
 </p>
-<h3 align="center">Fluent Reader</h3>
+<h3 align="center">Fluentflame Reader</h3>
 <p align="center">A modern desktop RSS reader</p>
 <p align="center">
   <img src="https://img.shields.io/github/v/release/yang991178/fluent-reader?label=version" />

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -1,6 +1,6 @@
 appId: org.fluentflame.fluentflamereader
-productName: Fluent Flame Reader
-copyright: Fluent Flame Copyright © 2025 Nube & Individual Collaborators. Original copyright © 2020 Haoyuan Liu
+productName: Fluentflame Reader
+copyright: Fluentflame Copyright © 2025 Nube & Individual Collaborators. Original copyright © 2020 Haoyuan Liu
 files:
     - "./dist/**/*"
     - "!./dist/fontlist"
@@ -72,4 +72,4 @@ linux:
     category: Utility
     desktop:
         entry:
-            StartupWMClass: fluent-flame-reader
+            StartupWMClass: fluentflame-reader

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -28,14 +28,14 @@
         formatter = pkgs.nixfmt-tree;
         devShells = rec {
           ffr-fhs = pkgs.callPackage ./fhs_shell.nix { };
-          fluent-flame-reader = pkgs.callPackage ./shell.nix {
-            fluent-flame-reader = packages.fluent-flame-reader;
+          fluentflame-reader = pkgs.callPackage ./shell.nix {
+            fluentflame-reader = packages.fluentflame-reader;
           };
-          default = fluent-flame-reader;
+          default = fluentflame-reader;
         };
         packages = rec {
-          fluent-flame-reader = pkgs.callPackage ./package.nix { };
-          default = fluent-flame-reader;
+          fluentflame-reader = pkgs.callPackage ./package.nix { };
+          default = fluentflame-reader;
         };
       }
     );

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,9 +1,10 @@
 {
   buildNpmPackage,
+  copyDesktopItems,
   electron,
   fetchFromGitHub,
-  makeWrapper,
   makeDesktopItem,
+  makeWrapper,
   ...
 }:
 let
@@ -12,10 +13,10 @@ let
 in
 
 buildNpmPackage rec {
-  pname = "fluent-flame-reader";
+  pname = "fluentflame-reader";
   version = "1.1.4";
   src = ../.;
-  npmDepsHash = "sha256-BvQrfVDu1B6boEIOG7DWFH8lPghn0FepFDlKrbqAxHA=";
+  npmDepsHash = "sha256-gSBSVea4vdz9wotqDiZmm56GxvfU4uRNt5cbQ17mDt4=";
   makeCacheWritable = true;
 
   env = {
@@ -26,6 +27,7 @@ buildNpmPackage rec {
   npmFlags = [ "--legacy-peer-deps" ];
 
   nativeBuildInputs = [
+    copyDesktopItems
     makeWrapper
     myElectron
   ];
@@ -71,7 +73,7 @@ buildNpmPackage rec {
     (makeDesktopItem {
       name = pname;
       exec = pname;
-      desktopName = "Fluent Flame Reader";
+      desktopName = "Fluentflame Reader";
       categories = [ "Utility" ];
       icon = pname;
     })

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -2,7 +2,7 @@
   mkShell,
 
   appimage-run,
-  fluent-flame-reader,
+  fluentflame-reader,
   nodePackages,
 }:
 
@@ -12,6 +12,6 @@ mkShell {
     appimage-run
   ];
   inputsFrom = [
-    fluent-flame-reader
+    fluentflame-reader
   ];
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "fluent-flame-reader",
+  "name": "fluentflame-reader",
   "version": "1.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "fluent-flame-reader",
+      "name": "fluentflame-reader",
       "version": "1.1.4",
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "fluent-flame-reader",
+  "name": "fluentflame-reader",
   "version": "1.1.4",
   "description": "Modern desktop RSS reader",
   "main": "./dist/electron.js",
@@ -17,7 +17,7 @@
   "keywords": [],
   "author": "Haoyuan Liu",
   "license": "BSD-3-Clause",
-  "repository": "github:FluentFlame/fluent-flame-reader",
+  "repository": "github:FluentFlame/fluentflame-reader",
   "devDependencies": {
     "@fluentui/react": "^7.126.2",
     "@types/lovefield": "^2.1.3",


### PR DESCRIPTION
In context, Fluentflame is consistently written without the dash. Unify to that.

Also fix the desktop icon issue as presented in PR #12.